### PR TITLE
ошибка поля weight в форме редактьитрования товара

### DIFF
--- a/frontend/src/admin/components/forms/product.vue
+++ b/frontend/src/admin/components/forms/product.vue
@@ -62,7 +62,7 @@
       </b-col>
       <b-col md="6">
         <b-form-group :label="$t('models.product.weight')">
-          <b-form-input v-model="record.old_price" type="number" step="0.01" />
+          <b-form-input v-model="record.weight" type="number" step="0.01" />
         </b-form-group>
       </b-col>
     </b-row>


### PR DESCRIPTION
из-за этого при вводе в 1 из полей меняется значение и в другом и товар создается с весом NULL, и при попытке оформить заказ он не отображается и отваливается с ошибкой, что нельзя записать NULL в поле weight в заказ, при этом 2 заказа всё же создались